### PR TITLE
Fix PostCSS options under version 6 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ See the [CSSNano Options][] for more details.
 ```coffee
 plugins:
   cssnano:
-    autoprefixer: {add: true}
+    preset: [
+      'advanced',
+      autoprefixer:
+        add: true
+    ]
 ```
 
 ## <a name="usage"></a> Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,35 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "autoprefixer": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.1.tgz",
+      "integrity": "sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.6.3",
+        "caniuse-lite": "^1.0.30000980",
+        "chalk": "^2.4.2",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.17",
+        "postcss-value-parser": "^4.0.0"
+      },
+      "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30000998",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000998.tgz",
+          "integrity": "sha512-8Tj5sPZR9kMHeDD9SZXIVr5m9ofufLLCG2Y4QwQrH18GIwG+kCc+zYdlR036ZRkuKjVVetyxeAgGA1xF7XdmzQ==",
+          "dev": true
+        },
+        "postcss-value-parser": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+          "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+          "dev": true
+        }
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -1033,6 +1062,20 @@
         "postcss": "^7.0.0"
       }
     },
+    "cssnano-preset-advanced": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-4.0.7.tgz",
+      "integrity": "sha512-j1O5/DQnaAqEyFFQfC+Z/vRlLXL3LxJHN+lvsfYqr7KgPH74t69+Rsy2yXkovWNaJjZYBpdz2Fj8ab2nH7pZXw==",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "^9.4.7",
+        "cssnano-preset-default": "^4.0.7",
+        "postcss-discard-unused": "^4.0.1",
+        "postcss-merge-idents": "^4.0.1",
+        "postcss-reduce-idents": "^4.0.2",
+        "postcss-zindex": "^4.0.1"
+      }
+    },
     "cssnano-preset-default": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
@@ -1796,6 +1839,12 @@
         "semver": "^5.3.0"
       }
     },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
     "normalize-url": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
@@ -1817,6 +1866,12 @@
       "requires": {
         "boolbase": "~1.0.0"
       }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -2042,6 +2097,42 @@
         "postcss": "^7.0.0"
       }
     },
+    "postcss-discard-unused": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-4.0.1.tgz",
+      "integrity": "sha512-/3vq4LU0bLH2Lj4NYN7BTf2caly0flUB7Xtrk9a5K3yLuXMkHMqMO/x3sDq8W2b1eQFSCyY0IVz2L+0HP8kUUA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0",
+        "uniqs": "^2.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+          "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^4.1.1",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "postcss-merge-idents": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-4.0.1.tgz",
+      "integrity": "sha512-43S/VNdF6II0NZ31YxcvNYq4gfURlPAAsJW/z84avBXQCaP4I4qRHUH18slW/SOlJbcxxCobflPNUApYDddS7A==",
+      "dev": true,
+      "requires": {
+        "cssnano-util-same-parent": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      }
+    },
     "postcss-merge-longhand": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
@@ -2234,6 +2325,16 @@
         "postcss-value-parser": "^3.0.0"
       }
     },
+    "postcss-reduce-idents": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-4.0.2.tgz",
+      "integrity": "sha512-Tz70Ri10TclPoCtFfftjFVddx3fZGUkr0dEDbIEfbYhFUOFQZZ77TEqRrU0e6TvAvF+Wa5VVzYTpFpq0uwFFzw==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      }
+    },
     "postcss-reduce-initial": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
@@ -2291,6 +2392,17 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+    },
+    "postcss-zindex": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-4.0.1.tgz",
+      "integrity": "sha512-d/8BlQcUdEugZNRM9AdCA2V4fqREUtn/wcixLN3L6ITgc2P/FMcVVYz8QZkhItWT9NB5qr8wuN2dJCE4/+dlrA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "uniqs": "^2.0.0"
+      }
     },
     "private": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-core": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "chai": "~4.1.2",
+    "cssnano-preset-advanced": "^4.0.7",
     "mocha": "^6.1.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,6 @@ class CSSNanoOptimizer {
     this.options = {
       // Write sourcemap
       sourcemap: true,
-      // Autoprefixer
-      autoprefixer: {add: false}
     };
     
     // Merge config
@@ -37,13 +35,11 @@ class CSSNanoOptimizer {
       }
     };
     
-    for (let k in this.options) { opts[k] = this.options[k]; }
-    
     if (params.map) {
       opts.map.prev = params.map.toJSON();
     }
     
-    return cssnano.process(params.data, opts).then(result => callback(null, { data: result.css, map: result.map.toJSON() }));
+    return cssnano.process(params.data, opts, this.options).then(result => callback(null, { data: result.css, map: result.map.toJSON() }));
   }
 }
 CSSNanoOptimizer.initClass();

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ class CSSNanoOptimizer {
       // Write sourcemap
       sourcemap: true,
     };
-    
+
     // Merge config
     const cfg = (this.config.plugins != null ? this.config.plugins.cssnano : undefined) != null ? (this.config.plugins != null ? this.config.plugins.cssnano : undefined) : {};
     for (let k in cfg) { this.options[k] = cfg[k]; }
@@ -26,7 +26,7 @@ class CSSNanoOptimizer {
 
   optimize(params, callback) {
     const opts = {
-      from: params.path,           
+      from: params.path,
       to:   params.path,
       map: {
         inline: false,
@@ -34,11 +34,11 @@ class CSSNanoOptimizer {
         sourcesContent: false
       }
     };
-    
+
     if (params.map) {
       opts.map.prev = params.map.toJSON();
     }
-    
+
     return cssnano.process(params.data, opts, this.options).then(result => callback(null, { data: result.css, map: result.map.toJSON() }));
   }
 }

--- a/test/fixtures/sample.css
+++ b/test/fixtures/sample.css
@@ -6,6 +6,7 @@ h1::before, h1:before {
     font-weight: normal;
     font-weight: normal;
     content: 'i ♥ cssnano';
+    user-select: none;
 }
 /* invalid placement */
 @charset "utf-8";

--- a/test/fixtures/sample.out.css
+++ b/test/fixtures/sample.out.css
@@ -1,1 +1,1 @@
-@charset "utf-8";h1:before{margin:10px 20px;color:red;-webkit-border-radius:16px;border-radius:16px;font-weight:400;content:"i ♥ cssnano"}
+@charset "utf-8";h1:before{margin:10px 20px;color:red;border-radius:16px;font-weight:400;content:"i ♥ cssnano";-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -17,7 +17,19 @@ describe('CSSNano', function() {
       paths: {
         public: path.join('test', 'public')
       },
-      optimize: true
+      optimize: true,
+      plugins: {
+        cssnano: {
+          preset: [
+            'advanced',
+            {
+              autoprefixer: {
+                add: true,
+              },
+            },
+          ],
+        },
+      },
     })
   );
 
@@ -35,7 +47,7 @@ describe('CSSNano', function() {
       version: 3,
       sources: [ 'sample.css' ],
       names: [],
-      mappings: 'AAAA,gBAQA,CARA,UACI,gBAA2B,CAC3B,SAAc,CACd,0BAA2B,CAC3B,kBAAmB,CAEnB,eAAmB,CACnB,qBACJ',
+      mappings: 'AAAA,gBASA,CATA,UACI,gBAA2B,CAC3B,SAAc,CAEd,kBAAmB,CAEnB,eAAmB,CACnB,qBAAsB,CACtB,wBAAiB,CAAjB,qBAAiB,CAAjB,oBAAiB,CAAjB,gBACJ',
       file: 'sample.css'
     };
     return cssnano.optimize({data: css, path: 'test/fixtures/sample.css'}, (err, data) => expect(data.map).to.be.eql(map));


### PR DESCRIPTION
The API was changed in version 6. Plugin options are now a separate argument.

Also, Autoprefixer is no longer available by default in cssnano 4. To bring that back, use the advanced cssnano preset. See the unit test for an example.